### PR TITLE
Refactor to use variation-normalizer Python library

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,153 @@
 # clinvar-gk-python
-Project for reading and normalizing ClinVar variants into GA4GH GKS forms
+
+Project for reading and normalizing ClinVar variants into GA4GH GKS forms.
+
+## Setup
+
+### Prerequisites
+
+1. **Docker** - Required to run the variation-normalization services
+2. **Python 3.11+** - Required for the main application
+3. **SeqRepo database** - Local sequence repository
+
+### Database Services Setup
+
+This project requires several database services that can be easily set up using the Docker compose configuration from the variation-normalization project.
+
+1. Download the compose.yaml file from variation-normalization v0.15.0 (matching the version in pyproject.toml):
+
+```bash
+curl -o variation-normalizer-compose.yaml https://raw.githubusercontent.com/cancervariants/variation-normalization/0.15.0/compose.yaml
+```
+
+2. Start the required services:
+
+```bash
+docker compose -f variation-normalizer-compose.yaml up -d
+```
+
+This will start:
+- **UTA database** (port 5432): Universal Transcript Archive for transcript mapping
+- **Gene Normalizer database** (port 8000): Gene normalization service
+- **Variation Normalizer API** (port 8001): Variation normalization service
+
+**Note on Port Conflicts**: If you already have services running on these ports, you can modify the port mappings in `variation-normalizer-compose.yaml`:
+- For UTA database: Change `5432:5432` to `5433:5432` (or another available port)
+- For Gene Normalizer: Change `8000:8000` to `8002:8000` (or another available port)
+- For Variation Normalizer API: Change `8001:80` to `8003:80` (or another available port)
+
+### Environment Configuration
+
+Set up the required environment variables. You can use the provided `env.sh` as a reference:
+
+```bash
+# SeqRepo configuration - Update path to your local SeqRepo installation
+export SEQREPO_ROOT_DIR=/Users/kferrite/dev/data/seqrepo/2024-12-20
+export SEQREPO_DATAPROXY_URL=seqrepo+file://${SEQREPO_ROOT_DIR}
+
+# Database URLs (using the Docker compose services)
+export UTA_DB_URL=postgresql://anonymous:anonymous@localhost:5432/uta/uta_20241220
+export GENE_NORM_DB_URL=http://localhost:8000
+```
+
+**Important**: If you modified the ports in the compose file, update the corresponding environment variables accordingly (e.g., change `5432` to `5433` in `UTA_DB_URL` if you changed the UTA port).
+
+Or source the provided environment file:
+```bash
+source env.sh
+```
+
+### Python Installation
+
+Install the project and its dependencies:
+
+```bash
+pip install -e '.[dev]'
+```
+
+## Running
+
+### Basic Usage
+
+Process a ClinVar variants file:
+
+```bash
+python clinvar_gk_pilot/main.py --filename gs://clinvar-gks/2025-07-06/dev/vi.json.gz --parallelism 4
+```
+
+### Alternative Entry Point
+
+You can also use the installed command:
+
+```bash
+clinvar-gk-pilot --filename gs://clinvar-gks/2025-07-06/dev/vi.json.gz --parallelism 4
+```
+
+### Command Line Options
+
+- `--filename`: Input file path (supports local files and gs:// URLs)
+- `--parallelism`: Number of worker processes for parallel processing (default: 1)
+- `--liftover`: Enable liftover functionality for genomic coordinate conversion
+
+### Example Commands
+
+Process a local file:
+```bash
+clinvar-gk-pilot --filename sample-input.ndjson.gz --parallelism 2
+```
+
+Process a file from Google Cloud Storage:
+```bash
+clinvar-gk-pilot --filename gs://clinvar-gks/2025-07-06/dev/vi.json.gz --parallelism 4
+```
+
+Process with liftover enabled:
+```bash
+clinvar-gk-pilot --filename gs://clinvar-gks/2025-07-06/dev/vi.json.gz --parallelism 2 --liftover
+```
+
+### Important Notes on Liftover
+
+When using the `--liftover` option, the application will send queries to the UTA PostgreSQL database for genomic coordinate conversion. Due to Docker's default shared memory constraints, high parallelism combined with liftover can cause out-of-memory errors.
+
+**Recommendations:**
+- Keep `--parallelism` on the lower side (2-4) when using `--liftover`
+- Alternatively, increase the `shm_size` for the UTA container in `variation-normalizer-compose.yaml`:
+
+```yaml
+services:
+  uta:
+    # ... other configuration
+    shm_size: 256m  # Add this line to increase shared memory to 256MB
+```
+
+## Development
+
+### Testing
+
+Run the test suite:
+```bash
+pytest
+```
+
+Run specific tests:
+```bash
+pytest test/test_cli.py::test_parse_args
+```
+
+### Code Quality
+
+Check and fix code quality issues:
+```bash
+# Check code quality
+./lint.sh
+
+# Apply automatic fixes
+./lint.sh apply
+```
+
+The lint script runs:
+- black (code formatting)
+- isort (import sorting)  
+- ruff (fast linter)
+- pylint (code analysis)

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Set up the required environment variables. You can use the provided `env.sh` as 
 
 ```bash
 # SeqRepo configuration - Update path to your local SeqRepo installation
-export SEQREPO_ROOT_DIR=/Users/kferrite/dev/data/seqrepo/2024-12-20
+export SEQREPO_ROOT_DIR=/usr/local/share/seqrepo/2024-12-20
 export SEQREPO_DATAPROXY_URL=seqrepo+file://${SEQREPO_ROOT_DIR}
 
 # Database URLs (using the Docker compose services)
@@ -147,7 +147,4 @@ Check and fix code quality issues:
 ```
 
 The lint script runs:
-- black (code formatting)
-- isort (import sorting)  
-- ruff (fast linter)
-- pylint (code analysis)
+- black, isort, ruff, pylint

--- a/clinvar_gk_pilot/cli.py
+++ b/clinvar_gk_pilot/cli.py
@@ -18,4 +18,9 @@ def parse_args(args: List[str]) -> dict:
             "Set to 0 to run in main thread."
         ),
     )
+    parser.add_argument(
+        "--liftover",
+        action="store_true",
+        help="Enable attempting to liftover non-GRCh38 genomic variants to GRCh38",
+    )
     return vars(parser.parse_args(args))

--- a/clinvar_gk_pilot/main.py
+++ b/clinvar_gk_pilot/main.py
@@ -236,21 +236,6 @@ def allele(clinvar_json: dict) -> dict:
         return {"errors": str(e)}
 
 
-def copy_number_count_vrspython(clinvar_json: dict) -> dict:
-    try:
-        tlr = cnv_translators[clinvar_json.get("assembly_version", "38")]
-        kwargs = {"copies": clinvar_json["absolute_copies"]}
-        vrs = tlr.translate_from(
-            var=clinvar_json["source"], fmt=clinvar_json["fmt"], **kwargs
-        )
-        return vrs.model_dump(exclude_none=True)
-    except Exception as e:
-        logger.error(
-            f"Exception raised in 'copy_number_count' processing: {clinvar_json}: {e}"
-        )
-        return {"errors": str(e)}
-
-
 def copy_number_change(clinvar_json: dict) -> dict:
     """
     Create a VRS CopyNumberChange variation using the variation-normalization module.
@@ -328,21 +313,6 @@ def copy_number_count(clinvar_json: dict) -> dict:
         return {"errors": error_msg}
 
 
-def copy_number_change_vrspython(clinvar_json: dict) -> dict:
-    try:
-        tlr = cnv_translators[clinvar_json.get("assembly_version", "38")]
-        kwargs = {"copy_change": clinvar_json["copy_change_type"]}
-        vrs = tlr.translate_from(
-            var=clinvar_json["source"], fmt=clinvar_json["fmt"], **kwargs
-        )
-        return vrs.model_dump(exclude_none=True)
-    except Exception as e:
-        logger.error(
-            f"Exception raised in 'copy_number_change' processing: {clinvar_json}: {e}"
-        )
-        return {"errors": str(e)}
-
-
 def partition_file_lines_gz(local_file_path_gz: str, partitions: int) -> List[str]:
     """
     Split `local_file_path_gz` into `partitions` roughly equal parts by line count.
@@ -376,7 +346,7 @@ def initialize_variation_normalizer_ref_data():
     script_url = "https://raw.githubusercontent.com/GenomicMedLab/variation-normalizer-manuscript/issue-116/analysis/download_cool_seq_tool_files.py"
 
     # Download the script
-    response = requests.get(script_url)
+    response = requests.get(script_url, timeout=30)
     response.raise_for_status()
 
     # Create a temporary file and write the script content

--- a/clinvar_gk_pilot/main.py
+++ b/clinvar_gk_pilot/main.py
@@ -54,7 +54,8 @@ def process_line(line: str, opts: dict = None) -> str:
     """
     clinvar_json = json.loads(line)
     result = None
-    if clinvar_json.get("issue") is None:
+    # if clinvar_json.get("issue") is None:
+    if True:
         cls = clinvar_json["vrs_class"]
         if cls == "Allele":
             result = allele(clinvar_json, opts or {})
@@ -242,16 +243,6 @@ def process_as_json(
     print(f"Output written to {output_file_name}")
 
 
-# def allele(clinvar_json: dict, opts: dict) -> dict:
-#     try:
-#         tlr = allele_translators[clinvar_json.get("assembly_version", "38")]
-#         vrs = tlr.translate_from(var=clinvar_json["source"], fmt=clinvar_json["fmt"])
-#         return vrs.model_dump(exclude_none=True)
-#     except Exception as e:
-#         logger.error(f"Exception raised in 'allele' processing: {clinvar_json}: {e}")
-#         return {"errors": str(e)}
-
-
 def allele(clinvar_json: dict, opts: dict) -> dict:
     try:
         assembly_version = clinvar_json.get("assembly_version", "38")
@@ -285,8 +276,9 @@ def allele(clinvar_json: dict, opts: dict) -> dict:
         else:
             raise ValueError(f"Unsupported format: {fmt}")
     except Exception as e:
-        logger.error(f"Exception raised in 'allele' processing: {clinvar_json}: {e}")
-        return {"errors": str(e)}
+        error_msg = f"Unexpected error: {repr(e)}"
+        logger.error(f"Exception in allele: {clinvar_json}: {error_msg}")
+        return {"errors": error_msg}
 
 
 def copy_number_change(clinvar_json: dict, opts: dict) -> dict:
@@ -324,7 +316,7 @@ def copy_number_change(clinvar_json: dict, opts: dict) -> dict:
             return {"errors": json.dumps(result.warnings)}
 
     except Exception as e:
-        error_msg = f"Unexpected error: {e}"
+        error_msg = f"Unexpected error: {repr(e)}"
         logger.error(f"Exception in copy_number_change: {clinvar_json}: {error_msg}")
         return {"errors": error_msg}
 
@@ -365,7 +357,7 @@ def copy_number_count(clinvar_json: dict, opts: dict) -> dict:
             return {"errors": json.dumps(result.warnings)}
 
     except Exception as e:
-        error_msg = f"Unexpected error: {e}"
+        error_msg = f"Unexpected error: {repr(e)}"
         logger.error(f"Exception in copy_number_count: {clinvar_json}: {error_msg}")
         return {"errors": error_msg}
 

--- a/clinvar_gk_pilot/main.py
+++ b/clinvar_gk_pilot/main.py
@@ -263,9 +263,10 @@ def allele(clinvar_json: dict, opts: dict) -> dict:
                 raise ValueError(
                     f"Unexpected assembly '{assembly_version}' for SPDI expression {source}"
                 )
-            return query_handler.vrs_python_tlr.translate_from(
-                source, fmt=fmt
-            ).model_dump(exclude_none=True)
+            vrs_variant = query_handler.vrs_python_tlr.translate_from(source, fmt=fmt)
+            if vrs_variant.location.sequence:
+                vrs_variant.location.sequence = None
+            return vrs_variant.model_dump(exclude_none=True)
         elif fmt == "hgvs":
             if opts.get("liftover", False):
                 # do /normalize. This also automatically tries to liftover to GRCh38
@@ -275,7 +276,10 @@ def allele(clinvar_json: dict, opts: dict) -> dict:
                     )
                 )
                 if result.variation:
-                    return result.variation.model_dump(exclude_none=True)
+                    vrs_variant = result.variation
+                    if vrs_variant.location.sequence:
+                        vrs_variant.location.sequence = None
+                    return vrs_variant.model_dump(exclude_none=True)
                 else:
                     return {"errors": json.dumps(result.warnings)}
         else:

--- a/clinvar_gk_pilot/main.py
+++ b/clinvar_gk_pilot/main.py
@@ -249,10 +249,8 @@ def copy_number_count(clinvar_json: dict) -> dict:
         # Get baseline_copies by offsetting by one from absolute_copies
         if clinvar_json["variation_type"] in ["Deletion", "copy number loss"]:
             baseline_copies = absolute_copies + 1
-            # copy_change = CopyChange.LOSS
         elif clinvar_json["variation_type"] in ["Duplication", "copy number gain"]:
             baseline_copies = absolute_copies - 1
-            # copy_change = CopyChange.GAIN
         else:
             return {"errors": f"Unknown variation_type: {clinvar_json}"}
 
@@ -261,11 +259,6 @@ def copy_number_count(clinvar_json: dict) -> dict:
 
         def call_hgvs_to_copy_number_count():
             try:
-                # result = asyncio.run(
-                #     query_handler.to_copy_number_handler.hgvs_to_copy_number_count(
-                #         hgvs_expr=hgvs_expr, baseline_copies=baseline_copies
-                #     )
-                # ).copy_number_count.model_dump(exclude_none=True)
                 result = asyncio.run(
                     query_handler.to_copy_number_handler.hgvs_to_copy_number_count(
                         hgvs_expr=hgvs_expr, baseline_copies=baseline_copies

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,9 @@ dependencies = [
     "ga4gh.vrs[extras] @ git+https://github.com/ga4gh/vrs-python@2.1.3",
     "gunicorn==22.0.0",
     "flask~=3.0.3",
-    "variation-normalizer @ git+https://github.com/cancervariants/variation-normalization@0.15.0"
+    "requests~=2.0",
+    "variation-normalizer @ git+https://github.com/cancervariants/variation-normalization@0.15.0",
+    # "variation-normalizer-manuscript @ git+https://github.com/GenomicMedLab/variation-normalizer-manuscript@issue-116",
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,9 +9,10 @@ license = { text = "MIT" }
 classifiers = ["Programming Language :: Python :: 3"]
 dependencies = [
     "google-cloud-storage~=2.13.0",
-    "ga4gh.vrs[extras] @ git+https://github.com/ga4gh/vrs-python@2.1.1",
+    "ga4gh.vrs[extras] @ git+https://github.com/ga4gh/vrs-python@2.1.3",
     "gunicorn==22.0.0",
     "flask~=3.0.3",
+    "variation-normalizer @ git+https://github.com/cancervariants/variation-normalization@0.15.0"
 ]
 dynamic = ["version"]
 

--- a/test/test_cli.py
+++ b/test/test_cli.py
@@ -6,4 +6,5 @@ def test_parse_args():
     opts = parse_args(argv)
     assert opts["filename"] == "test.txt"
     assert opts["parallelism"] == 1
-    assert len(opts) == 2
+    assert opts["liftover"] is False
+    assert len(opts) == 3


### PR DESCRIPTION
- Update handlers for `Allele`, `CopyNumberCount`, `CopyNumberChange` to use methods in the `variation-normalization` code
- Update worker threading to add a per-worker event loop

This does change the prereqs for running this process.

The VICC-customized UTA must be used as it adds a table which is referenced in some operations by the `variation-normalization` code. The compose.yaml below includes this and it includes a necessary gene-normalizer dynamodb server. Change the local ports as necessary to avoid collisions.

https://github.com/cancervariants/variation-normalization/blob/0.15.0/compose.yaml

It also makes some changes to add an asyncio event loop to each worker process so they can execute calls into the async `variation-normalization` functions. A future feature here may be to update our code to use asyncio.